### PR TITLE
Update dependencies clear up the build file a bit

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,5 +1,7 @@
 module.exports = function(grunt) {
 
+  require('load-grunt-tasks')(grunt);
+
   var poke_base_db = [
     './db/moves/moves.js',
     './db/moves/move_message.js',
@@ -115,14 +117,11 @@ module.exports = function(grunt) {
     './app/assets/javascript/teambuilder.js'
   ];
 
-  //Initializing the configuration object
     grunt.initConfig({
-
-      // Task configuration
     less: {
         development: {
             options: {
-              compress: true,  //minifying the result
+              compress: true
             },
             files: {
               //compiling frontend.less into frontend.css
@@ -181,7 +180,7 @@ module.exports = function(grunt) {
     },
     uglify: {
       options: {
-        mangle: false  // Use if you want the names of your functions and variables unchanged
+        mangle: true
       },
       frontend: {
         files: {
@@ -194,55 +193,38 @@ module.exports = function(grunt) {
         }
       },
     },
-    phpunit: {
-        classes: {
-        },
-        options: {
-        }
-    },
     watch: {
+        // run tasks when certain files are changed
         js_frontend: {
           files: js_frontend,
-          tasks: ['concat:js_frontend'/*,'uglify:frontend'*/],     //tasks to run
+          tasks: ['concat:js_frontend'/*,'uglify:frontend'*/],
           options: {
-            livereload: true                        //reloads the browser
+            livereload: true
           }
         },
         js_backend: {
           files: js_backend,
-          tasks: ['concat:js_backend','uglify:backend'],     //tasks to run
+          tasks: ['concat:js_backend','uglify:backend'],
           options: {
-            livereload: true                        //reloads the browser
+            livereload: true
           }
         },
         simple_copy: {
           files: ['./views/index.kiwi'],
-          tasks: ['concat:simple_copy'],     //tasks to run
+          tasks: ['concat:simple_copy'],
           options: {
-            livereload: true                        //reloads the browser
+            livereload: true
           }
         },
         less: {
-          files: ['./app/assets/stylesheets/*.less'],  //watched files
-          tasks: ['less'],                          //tasks to run
+          files: ['./app/assets/stylesheets/*.less'],
+          tasks: ['less'],
           options: {
-            livereload: true                        //reloads the browser
+            livereload: true
           }
-        },
- /*       tests: {
-          files: ['app/controllers/*.php','app/models/*.php'],  //the task will run only when you save files in this location
-          tasks: ['phpunit']
-        }*/
+        }
       }
     });
-
-  // Plugin loading
-  grunt.loadNpmTasks('grunt-contrib-concat');
-  grunt.loadNpmTasks('grunt-contrib-watch');
-  grunt.loadNpmTasks('grunt-contrib-less');
-  grunt.loadNpmTasks('grunt-contrib-uglify');
-  grunt.loadNpmTasks('grunt-contrib-copy');
-  //grunt.loadNpmTasks('grunt-phpunit');
 
   // Task definition
   grunt.registerTask('default', ['watch']);

--- a/package.json
+++ b/package.json
@@ -2,10 +2,6 @@
   "name": "po-web",
   "version": "0.0.0",
   "description": "Webclient for PO",
-  "main": "index.js",
-  "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
-  },
   "repository": {
     "type": "git",
     "url": "https://github.com/coyotte508/po-web"
@@ -20,12 +16,13 @@
     "bower": "^1.5.2",
     "compression": "^1.6.2",
     "express": "^4.13.3",
-    "grunt": "^0.4.5",
-    "grunt-contrib-concat": "^0.5.1",
-    "grunt-contrib-copy": "^0.8.1",
+    "grunt": "^1.0.1",
+    "grunt-contrib-concat": "^1.0.1",
+    "grunt-contrib-copy": "^1.0.0",
     "grunt-contrib-less": "^1.0.1",
-    "grunt-contrib-uglify": "^0.9.1",
-    "grunt-contrib-watch": "^0.6.1",
-    "kiwi": "^0.2.2"
+    "grunt-contrib-uglify": "^2.0.0",
+    "grunt-contrib-watch": "^1.0.0",
+    "kiwi": "^0.2.2",
+    "load-grunt-tasks": "^3.5.2"
   }
 }


### PR DESCRIPTION
Most projects are using grunt-load-tasks. No reason to have to update multiple lists every time we add a dependency.

Got rid of references to phpunit. No idea why we'd need that at all.

Set uglify to mangle names. Minification in addition to gzip doesn't really provide a whole lot of savings. It's not like we're debugging minified code.

There were some unnecessary comments that were getting copied and pasted around the watch task so I removed those and just added a 1 line summary of the task. Removed a few redundant comments such as pointing out that initConfig is configuration, hope that's fine :x
