### PR TITLE
Comment out Notification.requestPermission code

### DIFF
--- a/app/assets/javascript/pms/pmtab.js
+++ b/app/assets/javascript/pms/pmtab.js
@@ -102,15 +102,15 @@ pmtab.disconnect = function() {
     });
 };
 
-$(function() {
-    if ("Notification" in window) {
-        window.Notification.requestPermission(function(result) {
-          if (result === 'denied') {
-            return;
-          } else if (result === 'default') {
-            return;
-          }
-          // Do something with the granted permission.
-        });
-    }
-});
+// $(function() {
+//    if ("Notification" in window) {
+//         window.Notification.requestPermission(function(result) {
+//           if (result === 'denied') {
+//             return;
+//           } else if (result === 'default') {
+//             return;
+//           }
+           // Do something with the granted permission.
+//         });
+//     }
+// });


### PR DESCRIPTION
We aren't doing anything with the granted permission, so there is no point in asking for permission so far.
And Chrome support for the Notification API will be dropped for applications with insecure origins starting with Chrome version 61. See https://goo.gl/rStTGz